### PR TITLE
Chore: update documentation and upgrade package version to v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 You can install `tmb` as a dev dependency:
 
 ```bash
-npm install tmb --save-dev
+npm install @govindgovind852/tmb --save-dev
 ```
 
 ## Usage
@@ -15,13 +15,15 @@ npm install tmb --save-dev
 After installation, you can use the CLI tool by running:
 
 ```bash
-npx tmb [yaml-file-path]
+npx @govindgovind852/tmb add-module [yaml-file-path]
 ```
 
 or
 
+add this in your package script
+
 ```bash
-tmb [yaml-file-path]
+"tmb": "tmb add-module [yaml-file-path]"
 ```
 
 If no file path is provided, the default `./mgrc.yaml` will be used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "tmb",
-  "version": "0.0.2",
+  "name": "@govindgovind852/tmb",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tmb",
-      "version": "0.0.2",
+      "name": "@govindgovind852/tmb",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "inquirer": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govindgovind852/tmb",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A tool to define templates and generate modules using YAML configurations.",
   "main": "dist/index.js",
   "bin": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,6 +102,7 @@
   "exclude": [
     "node_modules", // Exclude node_modules by default
     "dist", // Exclude the dist folder
-    "template-module" // Exclude the template-module folder
+    "template-module", // Exclude the template-module folder
+    "src/modules" // Exclude the src/modules folder
   ]
 }


### PR DESCRIPTION
This pull request includes updates to the installation and usage instructions for the `tmb` tool, as well as a version bump in the `package.json` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R26): Updated the installation command to use the scoped package name `@govindgovind852/tmb` and modified the usage instructions to include the `add-module` command. Also added an example of how to add the command to a package script.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the version from `0.0.3` to `0.0.4`.